### PR TITLE
Fix compilation on r18

### DIFF
--- a/src/oauth2_response.erl
+++ b/src/oauth2_response.erl
@@ -171,7 +171,7 @@ to_proplist(Response) ->
     response_foldr(Response, fun(Key, Value, Acc) -> [{Key, Value} | Acc] end, []).
 
 -ifndef(pre17).
--spec to_map(response()) -> map(binary(), any()).
+-spec to_map(response()) -> #{binary() => any()}.
 to_map(Response) ->
     response_foldr(Response, fun(Key, Value, Acc) -> maps:put(Key, Value, Acc) end, maps:new()).
 -endif.


### PR DESCRIPTION
This change allows oauth2 to compile on erlang r18. This change also still work on r17.
